### PR TITLE
fix for django 2.1/2.2

### DIFF
--- a/django_postgres_extensions/admin/options.py
+++ b/django_postgres_extensions/admin/options.py
@@ -1,8 +1,9 @@
 from django.contrib.admin.options import ModelAdmin
-from django.utils.translation import string_concat, ugettext as _
+from django.utils.translation import ugettext as _
 from django.forms.widgets import CheckboxSelectMultiple, SelectMultiple
 from django_postgres_extensions.models import ArrayManyToManyField
 from django.contrib.admin import widgets
+
 
 class PostgresAdmin(ModelAdmin):
 
@@ -35,7 +36,7 @@ class PostgresAdmin(ModelAdmin):
         if isinstance(form_field.widget, SelectMultiple) and not isinstance(form_field.widget, CheckboxSelectMultiple):
             msg = _('Hold down "Control", or "Command" on a Mac, to select more than one.')
             help_text = form_field.help_text
-            form_field.help_text = string_concat(help_text, ' ', msg) if help_text else msg
+            form_field.help_text = help_text + ' ' + msg if help_text else msg
         return form_field
 
     def formfield_for_dbfield(self, db_field, request, **kwargs):

--- a/django_postgres_extensions/admin/options.py
+++ b/django_postgres_extensions/admin/options.py
@@ -1,5 +1,6 @@
 from django.contrib.admin.options import ModelAdmin
 from django.utils.translation import ugettext as _
+from django.utils.text import format_lazy
 from django.forms.widgets import CheckboxSelectMultiple, SelectMultiple
 from django_postgres_extensions.models import ArrayManyToManyField
 from django.contrib.admin import widgets
@@ -36,7 +37,7 @@ class PostgresAdmin(ModelAdmin):
         if isinstance(form_field.widget, SelectMultiple) and not isinstance(form_field.widget, CheckboxSelectMultiple):
             msg = _('Hold down "Control", or "Command" on a Mac, to select more than one.')
             help_text = form_field.help_text
-            form_field.help_text = help_text + ' ' + msg if help_text else msg
+            form_field.help_text = format_lazy('{} {}', (help_text, msg)) if help_text else msg
         return form_field
 
     def formfield_for_dbfield(self, db_field, request, **kwargs):


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1 - the django.utils.translation.string_concat() is removed in v 2.1.  

Tested with v2.1 and 2.2 - albeit only for startup.