### PR TITLE
Support for Django 3.0

### DIFF
--- a/django_postgres_extensions/models/expressions.py
+++ b/django_postgres_extensions/models/expressions.py
@@ -1,5 +1,5 @@
 from django.db.models.expressions import F as BaseF, Value as BaseValue, Func, Expression
-from django.utils import six
+import six
 from django.contrib.postgres.fields.array import IndexTransform
 from django.utils.functional import cached_property
 from django.db.models.lookups import Transform

--- a/django_postgres_extensions/models/fields/related.py
+++ b/django_postgres_extensions/models/fields/related.py
@@ -6,7 +6,7 @@ from .related_descriptors import MultiReferenceDescriptor
 from django.db import models
 from django.db.models.fields.related import RECURSIVE_RELATIONSHIP_CONSTANT, lazy_related_operation
 from django.forms.models import ModelMultipleChoiceField
-from django.utils import six
+import six
 from django.utils.encoding import force_text
 from .related_lookups import RelatedArrayContains, RelatedArrayExact, RelatedArrayContainedBy, RelatedContainsItem, \
     RelatedArrayOverlap, RelatedAnyGreaterThan, RelatedAnyLessThanOrEqual, RelatedAnyLessThan, RelatedAnyGreaterThanOrEqual

--- a/django_postgres_extensions/models/functions.py
+++ b/django_postgres_extensions/models/functions.py
@@ -1,6 +1,6 @@
 from django.db.models.expressions import Func, Expression
 from django.db.models.sql.constants import GET_ITERATOR_CHUNK_SIZE
-from django.utils import six
+import six
 from .expressions import F, Value as V
 
 class SimpleFunc(Func):

--- a/django_postgres_extensions/models/sql/subqueries.py
+++ b/django_postgres_extensions/models/sql/subqueries.py
@@ -1,5 +1,5 @@
 from django.db.models.sql.subqueries import UpdateQuery as BaseUpdateQuery
-from django.utils import six
+import six
 from django.core.exceptions import FieldError
 
 class UpdateQuery(BaseUpdateQuery):


### PR DESCRIPTION
The Django 3.0.0 release notes specify that certain private Python 2 compatibility APIs were removed. Among those was django.utils.six. Changing it to `six`